### PR TITLE
Fix Playlist play + shuffle

### DIFF
--- a/lib/commands/play.js
+++ b/lib/commands/play.js
@@ -35,13 +35,12 @@ module.exports = {
     const matches = argv.uri.match(/spotify:user:(\w+):playlist:([a-zA-Z0-9]{22})/)
 
     if (matches) {
-      const user = matches[1]
       const playlist = matches[2]
-      argv.db.logger.info('Adding playlist of user \'' + user + '\': ' + playlist)
+      argv.db.logger.info('Adding playlist: ' + playlist)
 
       argv.uri = null
       argv.uris = []
-      handlePlaylist(argv, user, playlist)
+      handlePlaylist(argv, playlist)
       return
     }
 
@@ -72,7 +71,7 @@ function addTracks (argv) {
     })
 }
 
-function handlePlaylist (argv, user, playlist) {
+function handlePlaylist (argv, playlist) {
   if (!argv.db.search.expires || argv.db.search.expires <= new Date()) {
     argv.db.logger.info('Retrieve an access token')
     argv.db.spotify.clientCredentialsGrant()
@@ -85,26 +84,26 @@ function handlePlaylist (argv, user, playlist) {
         // Save the access token so that it's used in future calls
         argv.db.spotify.setAccessToken(data.body['access_token'])
 
-        lookupPlaylist(argv, user, playlist, 0)
+        lookupPlaylist(argv, playlist, 0)
       }
       , function (err) {
         argv.db.logger.error('Something went wrong when retrieving an access token', err)
       })
   } else {
-    lookupPlaylist(argv, user, playlist, 0)
+    lookupPlaylist(argv, playlist, 0)
   }
 }
 
-function lookupPlaylist (argv, user, playlist, offset) {
+function lookupPlaylist (argv, playlist, offset) {
   argv.db.logger.info('Looking up playlist tracks ' + (offset + 1) + '-' + (offset + 100))
 
-  argv.db.spotify.getPlaylistTracks(user, playlist, { offset: offset, limit: 100, fields: 'items,total' })
+  argv.db.spotify.getPlaylistTracks(playlist, { offset: offset, limit: 100, fields: 'items,total' })
     .then(function (data) {
       for (let i = 0; i < data.body.items.length; i++) {
         argv.uris.push(data.body.items[i].track.uri)
       }
       if (argv.uris.length < data.body.total) {
-        lookupPlaylist(argv, user, playlist, offset + 100)
+        lookupPlaylist(argv, playlist, offset + 100)
       } else {
         argv.db.logger.info('Adding a total of ' + argv.uris.length + ' tracks to the tracklist')
         addTracks(argv)

--- a/lib/commands/shuffle.js
+++ b/lib/commands/shuffle.js
@@ -17,7 +17,9 @@ module.exports = {
       })
       .catch(function () {})
       .then(function () {
-        argv.db.yargs.parse('tracks')
+        argv.db.yargs.parse('tracks', {
+          db: argv.db
+        })
       })
   }
 }


### PR DESCRIPTION
According to this comment( https://github.com/thelinmichael/spotify-web-api-node/issues/264#issuecomment-465130561), `getPlaylistTracks` doesn't use the user anymore.

Also, `shuffle` was not working because `db` was not being exposed to `tracks`